### PR TITLE
Decrease thresholds for codecov to fail

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,10 @@
 comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        threshold: 5%
+    patch:
+      default:
+        target: 70%


### PR DESCRIPTION
Now the overall project is allowed to drop by 5% and each new patch
should have a minimum of 70% coverage